### PR TITLE
kasserver: Switch from sha1 to plain authentication

### DIFF
--- a/kasserver/__init__.py
+++ b/kasserver/__init__.py
@@ -51,11 +51,8 @@ class KasServer:
         self._get_credentials()
 
     def _get_credentials(self):
-        def _sha1(string):
-            return None if not string else hashlib.sha1(string.encode()).hexdigest()
-
         self._username = os.environ.get("KASSERVER_USER", None)
-        self._auth_sha1 = _sha1(os.environ.get("KASSERVER_PASSWORD", None))
+        self._password = os.environ.get("KASSERVER_PASSWORD", None)
         if self._username:
             return
 
@@ -63,7 +60,7 @@ class KasServer:
         try:
             info = netrc.netrc().authenticators(server)
             self._username = info[0]
-            self._auth_sha1 = _sha1(info[2])
+            self._password = info[2]
         except (FileNotFoundError, netrc.NetrcParseError) as err:
             LOGGER.warning(
                 "Cannot load credentials for %s from .netrc: %s", server, err
@@ -72,8 +69,8 @@ class KasServer:
     def _request(self, request, params):
         request = {
             "KasUser": self._username,
-            "KasAuthType": "sha1",
-            "KasAuthData": self._auth_sha1,
+            "KasAuthType": "plain",
+            "KasAuthData": self._password,
             "KasRequestType": request,
             "KasRequestParams": params,
         }

--- a/tests/test_kasserver.py
+++ b/tests/test_kasserver.py
@@ -36,7 +36,6 @@ LOGGER = logging.getLogger(__name__)
 
 USERNAME = "username"
 PASSWORD = "password"
-PASSWORD_SHA1 = "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8"
 
 # pylint: disable=protected-access
 # pylint: disable=attribute-defined-outside-init
@@ -56,7 +55,7 @@ class TestKasServerCredentials:
         netrc.side_effect = FileNotFoundError("")
         server = KasServer()
         assert server._username == USERNAME
-        assert server._auth_sha1 == PASSWORD_SHA1
+        assert server._password == PASSWORD
 
     @staticmethod
     @mock.patch.dict("os.environ", {})
@@ -66,7 +65,7 @@ class TestKasServerCredentials:
         netrc.return_value.authenticators.return_value = (USERNAME, "", PASSWORD)
         server = KasServer()
         assert server._username == USERNAME
-        assert server._auth_sha1 == PASSWORD_SHA1
+        assert server._password == PASSWORD
 
     @staticmethod
     @mock.patch.dict("os.environ", {})
@@ -76,7 +75,7 @@ class TestKasServerCredentials:
         netrc.side_effect = FileNotFoundError("")
         server = KasServer()
         assert not server._username
-        assert not server._auth_sha1
+        assert not server._password
 
 
 class TestKasServer:
@@ -186,8 +185,8 @@ class TestKasServer:
         kasserver._request(self.REQUEST_TYPE, self.REQUEST_PARAMS)
         request = {
             "KasUser": USERNAME,
-            "KasAuthType": "sha1",
-            "KasAuthData": PASSWORD_SHA1,
+            "KasAuthType": "plain",
+            "KasAuthData": PASSWORD,
             "KasRequestType": self.REQUEST_TYPE,
             "KasRequestParams": self.REQUEST_PARAMS,
         }


### PR DESCRIPTION
All-Inkl discontinues their 'sha1' authentication method starting
December 2022.

Fix #4