### PR TITLE
kasserver: Respect flood delay

### DIFF
--- a/tests/test_kasserver.py
+++ b/tests/test_kasserver.py
@@ -90,7 +90,7 @@ class TestKasServer:
             "key": "Response",
             "value": {
                 "item": [
-                    {},
+                    {"key": "KasFloodDelay", "value": 0},
                     {},
                     {
                         "key": "ReturnInfo",


### PR DESCRIPTION
Every API call contains a field 'KasFloodDelay' in the result. Wait this amount of seconds before attempting the next request.

Fix #9.
Supersede #10.